### PR TITLE
fix nested Type names in BAML -> XAML decompile

### DIFF
--- a/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
+++ b/Extensions/dnSpy.BamlDecompiler/XamlContext.cs
@@ -89,6 +89,16 @@ namespace dnSpy.BamlDecompiler {
 			}
 		}
 
+		static string NestedReflectionName(ITypeDefOrRef type, out string clrNs)
+		{
+			var name = type.ReflectionFullName;
+			while (type.DeclaringType is ITypeDefOrRef t2)
+				type = t2;
+			clrNs = type.ReflectionNamespace;
+			name = name.Substring(clrNs.Length + 1);
+			return name;
+		}
+		
 		public XamlType ResolveType(ushort id) {
 			if (typeMap.TryGetValue(id, out var xamlType))
 				return xamlType;
@@ -106,10 +116,10 @@ namespace dnSpy.BamlDecompiler {
 				type = TypeNameParser.ParseReflectionThrow(Module, typeRec.TypeFullName, new DummyAssemblyRefFinder(assembly));
 			}
 
-			var clrNs = type.ReflectionNamespace;
+			var name = NestedReflectionName(type, out string clrNs);
 			var xmlNs = XmlNs.LookupXmlns(assembly, clrNs);
 
-			typeMap[id] = xamlType = new XamlType(assembly, clrNs, type.ReflectionName, GetXmlNamespace(xmlNs)) {
+			typeMap[id] = xamlType = new XamlType(assembly, clrNs, name, GetXmlNamespace(xmlNs)) {
 				ResolvedType = type
 			};
 


### PR DESCRIPTION
Nested Type names were quite broken.  Of course they are doomed in XAML anyway, but this solves a fair about of the corruption and crashing-out-of-decompile problems.

Examples now much improved:
System.Activities.Presentation.View.TypeBrowser
System.Activities.Core.Presentation.FlowchartDesigner